### PR TITLE
Set QoS and node names

### DIFF
--- a/perception_system/src/perception_system/CollisionServer.cpp
+++ b/perception_system/src/perception_system/CollisionServer.cpp
@@ -109,9 +109,9 @@ CollisionServer::on_configure(const rclcpp_lifecycle::State & state)
   sync_->registerCallback(std::bind(&CollisionServer::sync_cb, this, _1, _2, _3));
   // Latched topic
   point_cloud_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(
-    "pointcloud_filtered", rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
+    "pointcloud_filtered", 1);
   depth_pub_ = create_publisher<sensor_msgs::msg::Image>(
-    "depth_filtered", rclcpp::QoS(rclcpp::KeepLast(1)).transient_local().reliable());
+    "depth_filtered", 1);
 
   return CallbackReturn::SUCCESS;
 }

--- a/perception_system/src/perception_system/ObjectsDetectionNode.cpp
+++ b/perception_system/src/perception_system/ObjectsDetectionNode.cpp
@@ -20,7 +20,7 @@ namespace perception_system
 {
 
 ObjectsDetectionNode::ObjectsDetectionNode(const rclcpp::NodeOptions & options)
-: rclcpp_cascade_lifecycle::CascadeLifecycleNode("perception_objects_detection_node", options)
+: rclcpp_cascade_lifecycle::CascadeLifecycleNode("perception_objects_detection", options)
 {
   // Declare the parameters
   this->declare_parameter("classes", "all");

--- a/perception_system/src/perception_system/PeopleDetectionNode.cpp
+++ b/perception_system/src/perception_system/PeopleDetectionNode.cpp
@@ -20,7 +20,7 @@ namespace perception_system
 {
 
 PeopleDetectionNode::PeopleDetectionNode(const rclcpp::NodeOptions & options)
-: rclcpp_cascade_lifecycle::CascadeLifecycleNode("perception_people_detection_node", options)
+: rclcpp_cascade_lifecycle::CascadeLifecycleNode("perception_people_detection", options)
 {
   // Create parameters
   this->declare_parameter("target_frame", "head_front_camera_link");


### PR DESCRIPTION
Hi @jmguerreroh 

May you consider the changes in this PR?
- Change in node names to be coherent across the project
- Set QoS to Volatile to use intra-process comms. I think this change won't have an impact on the program, but check it, please

Thanks!!