### PR TITLE
Listener modified to work with current robocup implmenetation

### DIFF
--- a/perception_system/CMakeLists.txt
+++ b/perception_system/CMakeLists.txt
@@ -48,7 +48,7 @@ set(dependencies
   # image_transport
   cv_bridge
   tf2_ros
-  geometry_msgs  
+  geometry_msgs
   # ament_index_cpp
   # image_transport
   # sensor_msgs
@@ -106,7 +106,7 @@ ament_target_dependencies(perception_listener ${dependencies})
 target_link_libraries(perception_listener ${PROJECT_NAME})
 
 install(TARGETS
- ${PROJECT_NAME}
+  ${PROJECT_NAME}
   dt_people
   dt_objects
   dt_debug
@@ -122,8 +122,7 @@ install(DIRECTORY launch models
         DESTINATION share/${PROJECT_NAME})
 
 install(DIRECTORY include/
-        DESTINATION include/
-      )
+        DESTINATION include/)
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   # the following line skips the linter which checks for copyrights

--- a/perception_system/include/perception_system/PerceptionListener.hpp
+++ b/perception_system/include/perception_system/PerceptionListener.hpp
@@ -66,6 +66,11 @@ public:
   std::vector<perception_system_interfaces::msg::Detection> get_by_id(const std::string & id);
   std::vector<perception_system_interfaces::msg::Detection> get_by_type(const std::string & type);
   void publicTFinterest();
+  // public tfs with custom sorting
+  void publicSortedTFinterest(std::function<bool(const perception_system_interfaces::msg::Detection&, const perception_system_interfaces::msg::Detection&)> comp = [](const perception_system_interfaces::msg::Detection& a, const perception_system_interfaces::msg::Detection& b) {
+    // Default sorting behavior
+    return a.center3d.position.z < b.center3d.position.z; 
+  });
 
   using CallbackReturnT =
     rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
@@ -89,7 +94,7 @@ private:
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
   void perception_callback(perception_system_interfaces::msg::DetectionArray::UniquePtr msg);
-  int publicTF(const perception_system_interfaces::msg::Detection & detected_object);
+  int publicTF(const perception_system_interfaces::msg::Detection & detected_object, const std::string & custom_suffix = "");
 
 
   double max_time_perception_;

--- a/perception_system/include/perception_system/PerceptionListener.hpp
+++ b/perception_system/include/perception_system/PerceptionListener.hpp
@@ -67,10 +67,12 @@ public:
   std::vector<perception_system_interfaces::msg::Detection> get_by_type(const std::string & type);
   void publicTFinterest();
   // public tfs with custom sorting
-  void publicSortedTFinterest(std::function<bool(const perception_system_interfaces::msg::Detection&, const perception_system_interfaces::msg::Detection&)> comp = [](const perception_system_interfaces::msg::Detection& a, const perception_system_interfaces::msg::Detection& b) {
-    // Default sorting behavior
-    return a.center3d.position.z < b.center3d.position.z; 
-  });
+  void publicSortedTFinterest(
+    std::function<bool(const perception_system_interfaces::msg::Detection &,
+    const perception_system_interfaces::msg::Detection &)> comp = [] (const perception_system_interfaces::msg::Detection & a, const perception_system_interfaces::msg::Detection & b) {
+      // Default sorting behavior
+      return a.center3d.position.z < b.center3d.position.z;
+    });
 
   using CallbackReturnT =
     rclcpp_lifecycle::node_interfaces::LifecycleNodeInterface::CallbackReturn;
@@ -94,7 +96,9 @@ private:
   std::unique_ptr<tf2_ros::TransformBroadcaster> tf_broadcaster_;
 
   void perception_callback(perception_system_interfaces::msg::DetectionArray::UniquePtr msg);
-  int publicTF(const perception_system_interfaces::msg::Detection & detected_object, const std::string & custom_suffix = "");
+  int publicTF(
+    const perception_system_interfaces::msg::Detection & detected_object,
+    const std::string & custom_suffix = "");
 
 
   double max_time_perception_;

--- a/perception_system/src/perception_system/DebugNode.cpp
+++ b/perception_system/src/perception_system/DebugNode.cpp
@@ -22,7 +22,7 @@ namespace perception_system
 DebugNode::DebugNode(const rclcpp::NodeOptions & options)
 : rclcpp_cascade_lifecycle::CascadeLifecycleNode("perception_debug_node", options)
 {
-    this->declare_parameter("target_frame", "head_front_camera_link");
+  this->declare_parameter("target_frame", "head_front_camera_link");
 }
 
 CallbackReturnT DebugNode::on_configure(const rclcpp_lifecycle::State & state)

--- a/perception_system/src/perception_system/ObjectsDetectionNode.cpp
+++ b/perception_system/src/perception_system/ObjectsDetectionNode.cpp
@@ -39,10 +39,9 @@ CallbackReturnT ObjectsDetectionNode::on_configure(const rclcpp_lifecycle::State
     get_logger(), "[%s] Configuring from [%s] state...", get_name(),
     state.label().c_str());
 
-  this->get_parameter("classes", classes_);  
+  this->get_parameter("classes", classes_);
   this->get_parameter("target_frame", frame_id_);
-  if (this->get_parameter("debug").as_bool())
-  {
+  if (this->get_parameter("debug").as_bool()) {
     this->add_activation("yolov8_debug_node");
   }
 

--- a/perception_system/src/perception_system/PeopleDetectionNode.cpp
+++ b/perception_system/src/perception_system/PeopleDetectionNode.cpp
@@ -38,8 +38,7 @@ CallbackReturnT PeopleDetectionNode::on_configure(const rclcpp_lifecycle::State 
     state.label().c_str());
 
   this->get_parameter("target_frame", frame_id_);
-  if (this->get_parameter("debug").as_bool())
-  {
+  if (this->get_parameter("debug").as_bool()) {
     this->add_activation("yolov8_debug_node");
   }
 

--- a/perception_system/src/perception_system/PerceptionListener.cpp
+++ b/perception_system/src/perception_system/PerceptionListener.cpp
@@ -32,10 +32,10 @@ limitations under the License.
 
 namespace perception_system
 {
-  using namespace std::chrono_literals;
+using namespace std::chrono_literals;
 
 PerceptionListener::PerceptionListener(const rclcpp::NodeOptions & options)
-: CascadeLifecycleNode("perception_listener","perception_system", options)
+: CascadeLifecycleNode("perception_listener", "perception_system", options)
 {
   this->declare_parameter("max_time_perception", 0.01);
   this->declare_parameter("max_time_interest", 0.01);
@@ -54,19 +54,18 @@ PerceptionListener::on_configure(const rclcpp_lifecycle::State & state)
     get_logger(), "[%s] Configuring from [%s] state...", get_name(),
     state.label().c_str());
 
-  this->get_parameter("max_time_perception", max_time_perception_);  
+  this->get_parameter("max_time_perception", max_time_perception_);
   this->get_parameter("max_time_interest", max_time_interest_);
   this->get_parameter("tf_frame_camera_", tf_frame_camera_);
   this->get_parameter("tf_frame_map_", tf_frame_map_);
-  if (this->get_parameter("debug").as_bool())
-  {
+  if (this->get_parameter("debug").as_bool()) {
     this->add_activation("yolov8_debug_node");
   }
 
   last_update_ = rclcpp::Clock(RCL_STEADY_TIME).now();
 
   tf_buffer_ = std::make_unique<tf2_ros::Buffer>(this->get_clock(), 120ms); // 30 Hz liveliness so it is always updated
-  tf_listener_ = std::make_unique<tf2_ros::TransformListener>(*tf_buffer_); 
+  tf_listener_ = std::make_unique<tf2_ros::TransformListener>(*tf_buffer_);
   tf_broadcaster_ = std::make_unique<tf2_ros::TransformBroadcaster>(this);
 
   return CallbackReturnT::SUCCESS;
@@ -250,9 +249,10 @@ PerceptionListener::get_by_type(const std::string & type)
 }
 
 // Create a transform from map to object and send it
-int 
+int
 PerceptionListener::publicTF(
-  const perception_system_interfaces::msg::Detection & detected_object, const std::string & custom_suffix)
+  const perception_system_interfaces::msg::Detection & detected_object,
+  const std::string & custom_suffix)
 {
   geometry_msgs::msg::TransformStamped map2camera_msg;
   try {
@@ -278,12 +278,14 @@ PerceptionListener::publicTF(
   tf2::fromMsg(map2camera_msg.transform, map2camera);
 
   tf2::Transform map2object = map2camera * camera2object;
-  
+
   // create a transform message from tf2::Transform
   geometry_msgs::msg::TransformStamped map2object_msg;
   map2object_msg.header.stamp = detected_object.header.stamp;
   map2object_msg.header.frame_id = tf_frame_map_;
-  map2object_msg.child_frame_id = (custom_suffix.empty()) ? detected_object.unique_id : (detected_object.class_name + "_" + custom_suffix);
+  map2object_msg.child_frame_id =
+    (custom_suffix.empty()) ? detected_object.unique_id : (detected_object.class_name + "_" +
+    custom_suffix);
   map2object_msg.transform = tf2::toMsg(map2object);
 
   tf_broadcaster_->sendTransform(map2object_msg);

--- a/perception_system/src/perception_system/PerceptionListener.cpp
+++ b/perception_system/src/perception_system/PerceptionListener.cpp
@@ -200,9 +200,9 @@ void PerceptionListener::set_interest(const std::string & id, bool status)
           id,
           {status, steady_clock.now()}));
       if (id.find("person") != std::string::npos) {
-        this->add_activation("perception_people_detection_node");
+        this->add_activation("perception_people_detection");
       } else {
-        this->add_activation("perception_objects_detection_node");
+        this->add_activation("perception_objects_detection");
       }
       RCLCPP_INFO(get_logger(), "Added interest: %s, %d", id.c_str(), status);
     } else {

--- a/perception_system/src/perception_system/PerceptionListener.cpp
+++ b/perception_system/src/perception_system/PerceptionListener.cpp
@@ -212,9 +212,9 @@ void PerceptionListener::set_interest(const std::string & id, bool status)
   } else {
     interests_.erase(id);
     if (id.find("person") != std::string::npos) {
-      this->remove_activation("perception_people_detection_node");
+      this->remove_activation("perception_people_detection");
     } else {
-      this->remove_activation("perception_objects_detection_node");
+      this->remove_activation("perception_objects_detection");
     }
     RCLCPP_INFO(get_logger(), "Removed interest: %s, %d", id.c_str(), status);
   }


### PR DESCRIPTION
So basically after the perception listener was modified to publish tfs, there are some workarounds i have to implement to be compatible with the current BT nodes of robocup. All is still compatible with the first version tho.

- I added a method that allows you to publish detection with a sorting mechanism
- Changed the tf_buffer constructor so the publish tfs will be always updated.
- The source frame was changed since this prevents noise from robot movements
- Now it allows you to use a different suffix in the tfs rather than the unique_id that yolo provides. This way tfs wont go until 
person_100000 and the maximum number is the largest number of detections. Eg if there are 2 people the max tf number will be person_1 (person_0 and person_1).

