### PR TITLE
remove pc publish when isolating PC

### DIFF
--- a/perception_system/src/perception_system/CollisionServer.cpp
+++ b/perception_system/src/perception_system/CollisionServer.cpp
@@ -491,7 +491,7 @@ void CollisionServer::isolate_pc_classes_service_callback(
   }
   response->filtered_pc = detection_cloud_msg;
   response->success = true;
-  point_cloud_pub_->publish(detection_cloud_msg);
+  //point_cloud_pub_->publish(detection_cloud_msg);
 }
 
 void CollisionServer::isolate_pc_background_service_callback(


### PR DESCRIPTION
When doing the pick, it is better to stop publishing the PC since moveit subscribes to it and a lot of info is missed when doing it.